### PR TITLE
Take guid input

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -15,13 +15,9 @@ RUN apt install -y python3 python3-pip mysql-client libmysqlclient-dev
 #Script requirements
 RUN apt install -y curl jq pigz
 
-#Install OCI CLI
-RUN curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh > install_oci_cli.sh && bash install_oci_cli.sh --accept-all-defaults && mkdir -p ~/.oci && cp ~/bin/oci /bin/oci
-
 #Compile and install FN5
 RUN git clone https://github.com/oxfordmmm/FN5.git && \
     cd FN5 && \
-    git checkout testing-docker && \ 
     bash build.sh && \
     cp fn5 /usr/bin/fn5 && \
     pip install -r requirements.txt

--- a/src/comparisons.cpp
+++ b/src/comparisons.cpp
@@ -506,8 +506,8 @@ void compute_loaded(int cutoff, vector<Sample*> samples){
 
 }
 
-void reference_compress(string path, string reference, unordered_set<int> mask){
-    Sample *s = new Sample(path, reference, mask);       
+void reference_compress(string path, string reference, unordered_set<int> mask, string guid){
+    Sample *s = new Sample(path, reference, mask, guid);
     save(save_dir+"/", s);
     cout << s->uuid << endl;
 }

--- a/src/fn5.cpp
+++ b/src/fn5.cpp
@@ -84,7 +84,13 @@ int main(int nargs, const char* args_[]){
     }
 
     if(check_flag(args, "--reference_compress")){
-        reference_compress(args.at("--reference_compress"), reference, mask);
+        string guid = "";
+        if(check_flag(args, "--guid")){
+            //If guid is given as an arg, use it
+            //If not, just use whatever can be found from the header
+            guid = args.at("--guid");
+        }
+        reference_compress(args.at("--reference_compress"), reference, mask, guid);
     }
 
 }

--- a/src/include/comparisons.hpp
+++ b/src/include/comparisons.hpp
@@ -166,8 +166,9 @@ void compute_loaded(int cutoff, vector<Sample*> samples);
 * @param path Path to a FASTA file
 * @param reference Reference nucleotides
 * @param mask Exclusion mask
+* @param guid GUID for the sample
 */
-void reference_compress(string path, string reference, unordered_set<int> mask);
+void reference_compress(string path, string reference, unordered_set<int> mask, string guid);
 
 /**
 * @brief Add a batch specified by sample saves in a given dir

--- a/src/include/sample.hpp
+++ b/src/include/sample.hpp
@@ -66,7 +66,7 @@ class Sample{
          * @param reference String of reference nucleotides
          * @param mask Genome indices to ignore (based on epidemialogical evidence)
          */
-        Sample(string filename, string reference, unordered_set<int> mask);
+        Sample(string filename, string reference, unordered_set<int> mask, string guid="");
 
         /**
          * @brief Sample constructor. Used for instanciated a previously saved Sample

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 
 
-Sample::Sample(string filename, string reference, unordered_set<int> mask){
+Sample::Sample(string filename, string reference, unordered_set<int> mask, string guid){
     char ch;
     fstream fin(filename, fstream::in);
     if(!fin.good()){
@@ -16,6 +16,7 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask){
     }
     //Deal with the header first
     //Assume last pipe separated value in header is UUID (at least for now)
+    string uuid_;
     while(fin >> noskipws >> ch){
         if(ch == '\n'){
             //Line has ended
@@ -23,12 +24,22 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask){
         }
         if(ch == '|'){
             //New pipe, so reset
-            uuid = "";
+            uuid_ = "";
         }
         else{
             //Add to the str
-            uuid += ch;
+            uuid_ += ch;
         }
+    }
+
+    //Check if we've been given a GUID instead
+    if(guid == ""){
+        //Nothing given, so use value from header
+        uuid = uuid_;
+    }
+    else{
+        //Given a GUID, so use it
+        uuid = guid;
     }
 
     int i = 0;


### PR DESCRIPTION
In order to ensure that FN5 can pick up the correct GUID for use as a foreign key within the `gpas` database, added a flag which allows specifying this from the CLI

`./fn5 --reference_compress <sample> --guid <run.id>`  should produce a save with the specified `<run.id>`