### PR TITLE
Fix/increase qc threshold

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -89,10 +89,11 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
     }
     fin.close();
 
-    //For a basic QC check we want to ensure that <80% of the sample is N
+    //For a basic QC check we want to ensure that <20% of the sample is N
+    //This should infer that the sample is >=80% ACGT
     //Inherently ref has no Ns, so total Ns == this->N.size()
     float total_size = reference.size();
-    qc_pass = N.size() / total_size < 0.8;
+    qc_pass = N.size() / total_size < 0.2;
 }
 
 Sample::Sample(unordered_set<int> a, unordered_set<int> c, unordered_set<int> g, unordered_set<int> t, unordered_set<int> n){

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -89,10 +89,10 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
     }
     fin.close();
 
-    //For a basic QC check we want to ensure that <50% of the sample is N
+    //For a basic QC check we want to ensure that <80% of the sample is N
     //Inherently ref has no Ns, so total Ns == this->N.size()
     float total_size = reference.size();
-    qc_pass = N.size() / total_size < 0.5;
+    qc_pass = N.size() / total_size < 0.8;
 }
 
 Sample::Sample(unordered_set<int> a, unordered_set<int> c, unordered_set<int> g, unordered_set<int> t, unordered_set<int> n){


### PR DESCRIPTION
Due to rapidly increasing size of saves (and so RAM usage) of real samples, increase threshold for QC pass to 80% ACGT