### PR TITLE
feat: use vector rather than unordered_set

### DIFF
--- a/src/include/sample.hpp
+++ b/src/include/sample.hpp
@@ -25,27 +25,27 @@ class Sample{
         /**
         * @brief Set of indices which this sample is `A` and the reference is not
         */
-        unordered_set<int> A;
+        vector<int> A;
 
         /**
         * @brief Set of indices which this sample is `C` and the reference is not
         */
-        unordered_set<int> C;
+        vector<int> C;
 
         /**
         * @brief Set of indices which this sample is `G` and the reference is not
         */
-        unordered_set<int> G;
+        vector<int> G;
 
         /**
         * @brief Set of indices which this sample is `T` and the reference is not
         */
-        unordered_set<int> T;
+        vector<int> T;
 
         /**
         * @brief Set of indices which this sample is `N`
         */
-        unordered_set<int> N;
+        vector<int> N;
 
         /**
         * @brief This sample's UUID. Assumed to be `FASTA_header.split("|")[-1]`
@@ -77,7 +77,7 @@ class Sample{
          * @param t Set of genome indices which this sample has an T, differing from the reference
          * @param n Set of genome indices which this sample has an N, differing from the reference
          */
-        Sample(unordered_set<int> a, unordered_set<int> c, unordered_set<int> g, unordered_set<int> t, unordered_set<int> n);
+        Sample(vector<int> a, vector<int> c, vector<int> g, vector<int> t, vector<int> n);
 
         /**
         * @brief Provide a custom implementation of `==` to allow equality checking
@@ -108,7 +108,7 @@ class Sample{
          * @param cutoff Distance to stop caring after (for speed)
          * @return int The distance between the two samples. If dist == cutoff + 1, the sample is further away and shouldn't be counted
          */
-        unordered_set<int> dist_x(unordered_set<int> this_x, unordered_set<int> this_n, unordered_set<int> sample_x, unordered_set<int> sample_n, unordered_set<int> acc, int cutoff);
+        unordered_set<int> dist_x(vector<int> this_x, vector<int> this_n, vector<int> sample_x, vector<int> sample_n, unordered_set<int> acc, int cutoff);
 };
 
 /**
@@ -117,7 +117,7 @@ class Sample{
 * @param to_save Set to save
 * @param filename Output filename
 */
-void save_n(unordered_set<int> to_save, string filename);
+void save_n(vector<int> to_save, string filename);
 
 /**
 * @brief Load an unordered set from a binary save on disk
@@ -125,7 +125,7 @@ void save_n(unordered_set<int> to_save, string filename);
 * @param filename File to load
 * @returns Unordered set of the ints stored in the file
 */
-unordered_set<int> load_n(string filename);
+vector<int> load_n(string filename);
 
 /**
 * @brief Save a sample to disk

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -57,31 +57,31 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
             //We have a difference from reference, so add to appropriate set
             switch (ch) {
                 case 'A':
-                    A.insert(i);
+                    A.push_back(i);
                     break;
                 case 'C':
-                    C.insert(i);
+                    C.push_back(i);
                     break;
                 case 'G':
-                    G.insert(i);
+                    G.push_back(i);
                     break;
                 case 'T':
-                    T.insert(i);
+                    T.push_back(i);
                     break;
                 case 'N':
-                    N.insert(i);
+                    N.push_back(i);
                     break;
                 case '-':
-                    N.insert(i);
+                    N.push_back(i);
                     break;
                 case 'X':
-                    N.insert(i);
+                    N.push_back(i);
                     break;
                 case 'O':
-                    N.insert(i);
+                    N.push_back(i);
                     break;
                 case 'Z':
-                    N.insert(i);
+                    N.push_back(i);
                     break;
             }
         }
@@ -96,7 +96,7 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
     qc_pass = N.size() / total_size < 0.2;
 }
 
-Sample::Sample(unordered_set<int> a, unordered_set<int> c, unordered_set<int> g, unordered_set<int> t, unordered_set<int> n){
+Sample::Sample(vector<int> a, vector<int> c, vector<int> g, vector<int> t, vector<int> n){
     A = a;
     C = c;
     G = g;
@@ -125,16 +125,16 @@ int Sample::dist(Sample* sample, int cutoff){
     return acc.size();
 }
 
-unordered_set<int> Sample::dist_x(unordered_set<int> this_x, unordered_set<int> this_n, unordered_set<int> sample_x, unordered_set<int> sample_n, unordered_set<int> acc, int cutoff){
+unordered_set<int> Sample::dist_x(vector<int> this_x, vector<int> this_n, vector<int> sample_x, vector<int> sample_n, unordered_set<int> acc, int cutoff){
     //Increment cutoff so we can reject distances > cutoff entirely
     cutoff++;
     for(const int& elem: this_x){
         if(acc.size() == cutoff){
             return acc;
         }
-        if(!sample_x.contains(elem)){ 
+        if(!binary_search(sample_x.begin(), sample_x.end(), elem)){
             //Not a in sample
-            if(!sample_n.contains(elem)){
+            if(!binary_search(sample_n.begin(), sample_n.end(), elem)){
                 //Not an N comparison either, so add
                 acc.insert(elem);
             }
@@ -144,9 +144,9 @@ unordered_set<int> Sample::dist_x(unordered_set<int> this_x, unordered_set<int> 
         if(acc.size() == cutoff){
             return acc;
         }
-        if(!this_x.contains(elem)){
+        if(!binary_search(this_x.begin(), this_x.end(), elem)){
             //Not a in sample
-            if(!this_n.contains(elem)){
+            if(!binary_search(this_n.begin(), this_n.end(), elem)){
                 //Not an N comparison either, so add
                 acc.insert(elem);
             }
@@ -156,7 +156,7 @@ unordered_set<int> Sample::dist_x(unordered_set<int> this_x, unordered_set<int> 
     return acc;
 }
 
-void save_n(unordered_set<int> to_save, string filename){
+void save_n(vector<int> to_save, string filename){
     fstream out(filename, fstream::binary | fstream::out);
     if(!out.good()){
         cout << "Error writing save file: " << filename << endl;
@@ -172,7 +172,7 @@ void save_n(unordered_set<int> to_save, string filename){
     out.close();
 }
 
-unordered_set<int> load_n(string filename){
+vector<int> load_n(string filename){
     //ate flag seeks to the end of the file
     fstream in(filename, fstream::binary | fstream::in | fstream::ate);
     if(!in.good()){
@@ -183,7 +183,7 @@ unordered_set<int> load_n(string filename){
     int size = in.tellg();
     in.seekg(0); //Go back to the start so we can read
 
-    unordered_set<int> output;
+    vector<int> output;
 
     for(int j=0;j<size/4;j++){
         //Read 4 characters from the file into a char array
@@ -193,10 +193,13 @@ unordered_set<int> load_n(string filename){
         //Convert the char array into an int and insert
         int *p;
         p = (int *) i;
-        output.insert(*p);
+        output.push_back(*p);
     }
 
     in.close();
+
+    //Make sure this is sorted or binary search breaks
+    sort(output.begin(), output.end());
 
     return output;
 }
@@ -217,7 +220,7 @@ void save(string filename, Sample* sample){
     for(int i=0; i<types.size(); i++){
         string f = filename + '.' + types.at(i);
         //Find out which one we need to save
-        unordered_set<int> toSave;
+        vector<int> toSave;
         switch (types.at(i)) {
             case 'A':
                 toSave = sample->A;
@@ -241,7 +244,7 @@ void save(string filename, Sample* sample){
 
 Sample* readSample(string filename){
     vector<char> types = {'A', 'C', 'G', 'T', 'N'};
-    vector<unordered_set<int>> loading;
+    vector<vector<int>> loading;
     for(int i=0; i<types.size(); i++){
         string f = filename + '.' + types.at(i);
         loading.push_back(load_n(f));

--- a/test/test_sample.cpp
+++ b/test/test_sample.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <unordered_set>
+#include <vector>
 #include "../src/include/sample.hpp"
 
 
@@ -53,11 +54,12 @@ TEST(sample, init){
     ASSERT_EQ(expected_mask, mask);
 
     //Empty set for checking things which shouldn't have changed
-    unordered_set<int> empty;
+    unordered_set<int> empty_mask;
+    vector<int> empty;
 
     //For simplicity here, check without a mask
-    Sample* s1 = new Sample("cases/dummy/1.fasta", reference, empty);
-    unordered_set<int> C_1 = {0};
+    Sample* s1 = new Sample("cases/dummy/1.fasta", reference, empty_mask);
+    vector<int> C_1 = {0};
     ASSERT_EQ(s1->uuid, "uuid1");
     ASSERT_EQ(empty, s1->A);
     ASSERT_EQ(C_1, s1->C);
@@ -65,8 +67,8 @@ TEST(sample, init){
     ASSERT_EQ(empty, s1->T);
     ASSERT_EQ(empty, s1->N);
 
-    Sample* s2 = new Sample("cases/dummy/2.fasta", reference, empty);
-    unordered_set<int> T_2 = {1};
+    Sample* s2 = new Sample("cases/dummy/2.fasta", reference, empty_mask);
+    vector<int> T_2 = {1};
     ASSERT_EQ(s2->uuid, "uuid2");
     ASSERT_EQ(empty, s2->A);
     ASSERT_EQ(empty, s2->C);
@@ -83,9 +85,9 @@ TEST(sample, init){
     ASSERT_EQ(empty, s2->T);
     ASSERT_EQ(empty, s2->N);
 
-    Sample* s3 = new Sample("cases/dummy/3.fasta", reference, empty);
-    unordered_set<int> G_3 = {14};
-    unordered_set<int> N_3 = {0};
+    Sample* s3 = new Sample("cases/dummy/3.fasta", reference, empty_mask);
+    vector<int> G_3 = {14};
+    vector<int> N_3 = {0};
     ASSERT_EQ(s3->uuid, "uuid3");
     ASSERT_EQ(empty, s3->A);
     ASSERT_EQ(empty, s3->C);
@@ -93,10 +95,10 @@ TEST(sample, init){
     ASSERT_EQ(empty, s3->T);
     ASSERT_EQ(N_3, s3->N);
 
-    Sample* s4 = new Sample("cases/dummy/4.fasta", reference, empty);
-    unordered_set<int> G_4 = {1};
-    unordered_set<int> N_4 = {0};
-    unordered_set<int> T_4 = {71};
+    Sample* s4 = new Sample("cases/dummy/4.fasta", reference, empty_mask);
+    vector<int> G_4 = {1};
+    vector<int> N_4 = {0};
+    vector<int> T_4 = {71};
     ASSERT_EQ(s4->uuid, "uuid4");
     ASSERT_EQ(empty, s4->A);
     ASSERT_EQ(empty, s4->C);


### PR DESCRIPTION
This should be a drop-in replacement for existing saves. Moves towards storing the samples using `vector` rather than `unordered_set`.  Results should be exactly identical - tests (other than syntax) are unchanged, and distances calculated have been manually checked

Rationale for this is that `unordered_set` uses an odd amount of RAM. Supposedly `unordered_set` has a linear RAM usage so is `O(N)`. Issue is that in practise, this is closer to `O(5N)`, which drastically increases RAM usage. I know limits are used for `O` notation so `O(5N) == O(N)` but this actually matters here. Original reasons for using `unordered_set` include:
* Functionally this computation is set theory, so I had assumed this would be optimised
* `O(1)` for pretty much every operation, including set membership

C++'s `vector` is a minimal wrapper around contiguous memory, so 2GB saves in --> 2GB RAM usage. Sorting on small vectors is fast, then binary search can be used as a replacement for `unordered_set.contains` in `O(log(N))` time. As an added bonus, this implementation is actually significantly faster than using `unordered_set` - computing the entire cryptic matrix in ~1min 20s on a laptop (similar results with `unordered_set` required a 64 core VM).

For adding a single sample, below is a comparison of RAM usage (via valgrind):
`unordered_set`:
![image](https://github.com/oxfordmmm/FN5/assets/67918949/7d550514-1e52-46b1-be9d-764d97482b04)

`vector`
![image](https://github.com/oxfordmmm/FN5/assets/67918949/7c530aaf-ba43-4198-8fb3-94a2950fceaf)

The `vector` implementation also shows a speed up by ~1 order of magnitude


