### PR TITLE
fix: due to pip/pypi oddities, fix build process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,13 +81,12 @@ jobs:
           build
           --user
 
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --outdir dist/
-          .
+      - name: Build a source tarball
+        run: |
+          export FN5_FIRST_PASS="YES"
+          python -m build --sdist --outdir dist
+          unset FN5_FIRST_PASS
+          python -m build --sdist --outdir dist
 
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 from pybind11.setup_helpers import Pybind11Extension
 from setuptools import setup
 from pathlib import Path
+import os
 
-__version__ = "v1.2.0"
+__version__ = "v1.2.2"
 
 try:
     this_directory = Path(__file__).parent
@@ -12,10 +13,20 @@ except FileNotFoundError:
     # Issues around packaging other readme means we can just skip on install
     long_description = "Fast, scalable SNP distance calculation from disk."
 
+# There's some odd behaviour going on here where pip won't install if this has the headers in it, 
+#   but they're required to be distributed with the rest of the files
+# So we have to run `python -m build` first including the headers, 
+#   then again without before running `twine`
+# So control with an env variable for automation
+if os.environ.get("FN5_FIRST_PASS", None):
+    files = sorted(["src/sample.cpp", "src/comparisons.cpp", "src/fn5_python.cpp", "src/include/sample.hpp", "src/include/comparisons.hpp"])
+else:
+    files = sorted(["src/sample.cpp", "src/comparisons.cpp", "src/fn5_python.cpp"])
+
 ext_modules = [
     Pybind11Extension(
         "fn5",
-        sorted(["src/sample.cpp", "src/comparisons.cpp", "src/fn5_python.cpp"]),
+        files,
         include_dirs=["src/include"],
         extra_compile_args=["-std=c++2a", "-O3", "-pthread"],
         # Example: passing in the version to the compiled code

--- a/src/fn5.cpp
+++ b/src/fn5.cpp
@@ -9,7 +9,7 @@ int main(int nargs, const char* args_[]){
     if(nargs == 2){
         string val = args_[1];
         if(val == "--version" || val == "-v"){
-            cout << "v1.2.0" << endl;
+            cout << "v1.2.2" << endl;
             return 0;
         }
     }


### PR DESCRIPTION
Current PyPi release is broken due to some oddities around header files and pip. Essentially, pip won't install with the header files in the sources, but they are required to build. Work around is to include the headers at build time, then re-write the setup.py in the build so the header files are included in the distribution but not in the sources passed to pip.
Should work with `pip install fn5==1.2.2rc2` - and this should fix the automated build process