### PR TITLE
feat: refactor save format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from pathlib import Path
 import os
 
-__version__ = "v1.2.2"
+__version__ = "v2.0.0"
 
 try:
     this_directory = Path(__file__).parent

--- a/src/fn5_python.cpp
+++ b/src/fn5_python.cpp
@@ -93,7 +93,7 @@ PYBIND11_MODULE(fn5, m) {
         -----------------------
 
         Args:
-            path (str): Base path to save to. Produces 5 files of <uuid>.A, <uuid>.C, ...
+            path (str): Directory to save to. Creates 1 file of `<path>/<uuid>.fn5`
             sample (fn5.Sample): Sample to save
         )pbdoc", py::arg("path"), py::arg("sample"));
     m.def("load", &readSample, R"pbdoc(
@@ -101,7 +101,7 @@ PYBIND11_MODULE(fn5, m) {
         -----------------------
 
         Args:
-            path (str): Base path to load from. i.e <some path>/<uuid> will load sample <uuid>
+            path (str): Path to load from. i.e <some path>/<uuid> or <some path>/<uuid>.fn5 will load sample <uuid>
         
         Returns:
             fn5.Sample: Loaded sample.

--- a/src/include/sample.hpp
+++ b/src/include/sample.hpp
@@ -114,7 +114,7 @@ class Sample{
 };
 
 /**
-* @brief Save the contents of an unordered set to disk using binary.
+* @brief **DEPRECIATED** Save the contents of an unordered set to disk using binary.
 *
 * @param to_save Set to save
 * @param filename Output filename
@@ -122,7 +122,7 @@ class Sample{
 void save_n(vector<int> to_save, string filename);
 
 /**
-* @brief Load an unordered set from a binary save on disk
+* @brief **DEPRECIATED** Load an unordered set from a binary save on disk
 *
 * @param filename File to load
 * @returns Unordered set of the ints stored in the file
@@ -132,7 +132,7 @@ vector<int> load_n(string filename);
 /**
 * @brief Save a sample to disk
 * 
-* @param filename Directory to save in. Actual saves will be [<filename>/<uuid>.A, <filename>/<uuid>.C, ...]
+* @param filename Directory to save in. Actual save will be <filename>/<uuid>.fn5
 * @param sample Sample to save
 */
 void save(string filename, Sample* sample);
@@ -140,7 +140,7 @@ void save(string filename, Sample* sample);
 /**
 * @brief Load a sample from disk
 * 
-* @param filename Base filename to load from. Actual saves will be [<filename>.A, <filename>.C, ...]
+* @param filename Base filename to load from. Actual saves will be <filename>/<uuid>.fn5
 * @returns Sample loaded from disk
 */
 Sample* readSample(string filename);

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -70,19 +70,7 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
                 case 'T':
                     T.push_back(i);
                     break;
-                case 'N':
-                    N.push_back(i);
-                    break;
-                case '-':
-                    N.push_back(i);
-                    break;
-                case 'X':
-                    N.push_back(i);
-                    break;
-                case 'O':
-                    N.push_back(i);
-                    break;
-                case 'Z':
+                default:
                     N.push_back(i);
                     break;
             }
@@ -328,7 +316,7 @@ Sample* readSample(string filename){
         try{
             return load_old(filename);
         }
-        catch (invalid_argument err) {
+        catch (invalid_argument &err) {
             // Not valid so try version with added `.fn5`
             // Mostly covering the gpas API use case
             filename += ".fn5";

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -1,5 +1,7 @@
 #include "include/sample.hpp"
+#include <cstddef>
 #include <stdexcept>
+#include <vector>
 
 /**
 * @brief Definition of the `Sample` class, and functions for saving and loading samples
@@ -172,6 +174,7 @@ void save_n(vector<int> to_save, string filename){
     out.close();
 }
 
+// DEPRECIATED
 vector<int> load_n(string filename){
     //ate flag seeks to the end of the file
     fstream in(filename, fstream::binary | fstream::in | fstream::ate);
@@ -203,7 +206,61 @@ vector<int> load_n(string filename){
     return output;
 }
 
+// For backwards compatibility
+// Loads the old-style saves, saves to new format then clean up old save files
+Sample* load_old(string filename){
+    if(filename.at(filename.size()-1) == '/'){
+        //Remove trailing / if req
+        filename.pop_back();
+    }
+    const vector<char> types = {'A', 'C', 'G', 'T', 'N'};
+    vector<vector<int>> loading;
+    for(unsigned int i=0; i<types.size(); i++){
+        string f = filename + '.' + types.at(i);
+        loading.push_back(load_n(f));
+    }
+    Sample *s = new Sample(loading.at(0), loading.at(1), loading.at(2), loading.at(3), loading.at(4));
+    
+    //Get the UUID from the filename
+    string uuid;
+    for(unsigned int i=0;i<filename.size();i++){
+        if(filename.at(i) == '/'){
+            //We only want the last part, so reset
+            uuid = "";
+        }
+        else{
+            uuid += filename.at(i);
+        }
+    }
+    s->uuid = uuid;
+
+    // We now have instanciated the old save, so write the new-style version and clean up
+    string base_filename = filename.substr(0, filename.size()-uuid.size());
+    save(base_filename, s);
+
+    for(unsigned int i=0; i<types.size(); i++){
+        string f = filename + '.' + types.at(i);
+        std::filesystem::remove(f);
+    }
+
+    return s;
+}
+
 void save(string filename, Sample* sample){
+    /**
+    File format:
+    Integers are written as binary integers (i.e 4 chars per int)
+    Each set of `<>` below is a single integer
+    Whitespace is for ease of reading, and is not included in the file
+
+    ```
+    <number of As in this file><value of A[0]><value of A[1]>...
+    <number of Cs in this file><value of C[0]><value of C[1]>...
+    <number of Gs in this file><value of G[0]><value of G[1]>...
+    <number of Ts in this file><value of T[0]><value of T[1]>...
+    <number of Ns in this file><value of N[0]><value of N[1]>...
+    ```
+    */
     if(!sample->qc_pass){
         //This sample has not passed QC, so don't save it
         cout << "||QC_FAIL: " << sample->uuid << "||" << endl;
@@ -215,9 +272,16 @@ void save(string filename, Sample* sample){
         filename += '/';
     }
     filename += sample->uuid;
-    vector<char> types = {'A', 'C', 'G', 'T', 'N'};
+    filename = filename + ".fn5";
+
+    const vector<char> types = {'A', 'C', 'G', 'T', 'N'};
+
+    fstream out(filename, fstream::binary | fstream::out);
+    if(!out.good()){
+        throw invalid_argument("Error writing save file: " + filename);
+    }
+
     for(unsigned int i=0; i<types.size(); i++){
-        string f = filename + '.' + types.at(i);
         //Find out which one we need to save
         vector<int> toSave;
         switch (types.at(i)) {
@@ -237,17 +301,110 @@ void save(string filename, Sample* sample){
                 toSave = sample->N;
                 break;
         }
-        save_n(toSave, f);
+        // Ideally, these should already be sorted, but sort on save for clarity
+        sort(toSave.begin(), toSave.end());
+
+        // First, write the number of ints we are going to write to make reading possible
+        // Annoying conversion as vector.size() is unsigned long
+        int nc_size = (toSave.size() & INT_MAX);
+        const int *p = &nc_size;
+        const char *p_ = (char *) p;
+        out.write(p_, 4);
+        // Then, iterate over elements, writing to the file
+        for(const int &elem: toSave){
+            const int *p = &elem;
+            const char *p_ = (char *) p;
+            out.write(p_, 4);
+        }
     }
+    out.close();
 }
 
 Sample* readSample(string filename){
-    vector<char> types = {'A', 'C', 'G', 'T', 'N'};
-    vector<vector<int>> loading;
-    for(unsigned int i=0; i<types.size(); i++){
-        string f = filename + '.' + types.at(i);
-        loading.push_back(load_n(f));
+    // Check for old-style saves to update if required
+    string ext = filename.substr(filename.find_last_of(".")+1);
+    if(ext != "fn5" && ext != "FN5"){
+        //  Not valid file extension for new saves so try load_old
+        try{
+            return load_old(filename);
+        }
+        catch (invalid_argument err) {
+            // Not valid so try version with added `.fn5`
+            // Mostly covering the gpas API use case
+            filename += ".fn5";
+        }
     }
+    // filename is <uuid>.fn5
+    const vector<string> supported_extensions = {".fn5", ".FN5"};
+    const vector<char> types = {'A', 'C', 'G', 'T', 'N'};
+
+    // Keep track of the values we read
+    vector<vector<int>> loading;
+
+    // Index of loading and types this is looking at
+    unsigned long int loading_idx = 0;
+
+    // Number of ints to read from the file for this type
+    int nc_size = -1;
+    // Counter of number of ints already read for this type
+    int current_size = 0;
+
+    //ate flag seeks to the end of the file
+    fstream in(filename, fstream::binary | fstream::in | fstream::ate);
+    if(!in.good()){
+        throw invalid_argument("Invalid save path: " + filename);
+    }
+    //Get the size of the file in bytes (we have to convert this as 1 int == 4 bytes)
+    int size = in.tellg();
+    in.seekg(0); //Go back to the start so we can read
+
+    if(size % 4 != 0){
+        // Should only be mutliples of 4 in the file
+        throw invalid_argument("Malformed save file: " + filename);
+    }
+
+    // This nucleotide's values
+    vector<int> acc;
+    for(int j=0;j<size/4;j++){
+        //Read 4 characters from the file into a char array
+        char i[4];
+        in.read(i, 4);
+
+        //Convert the char array into an int and insert
+        int *p;
+        p = (int *) i;
+
+        if(nc_size == -1){
+            // Size of the nucleotide to fetch has not been set, so this must be it
+            nc_size = *p;
+            current_size = 0;
+        }
+        else{
+            if(current_size == nc_size){
+                // Matched required number of ints, so add save and treat this int as the next nc_size
+                nc_size = *p;
+                current_size = 0;
+
+                loading.push_back(acc);
+                acc.clear();
+
+                loading_idx++;
+                if(loading_idx > types.size()){
+                    // Complain if this has happened incorrectly
+                    throw invalid_argument("Malformed save file: " + filename);
+                }
+            }
+            else{
+                acc.push_back(*p);
+                current_size++;
+            }
+        }
+    }
+    // Catch the last item
+    loading.push_back(acc);
+
+    in.close();
+
     Sample *s = new Sample(loading.at(0), loading.at(1), loading.at(2), loading.at(3), loading.at(4));
     
     //Get the UUID from the filename
@@ -255,6 +412,14 @@ Sample* readSample(string filename){
     if(filename.at(filename.size()-1) == '/'){
         //Remove trailing / if req
         filename.pop_back();
+    }
+    // Remove file extension if existing
+    for(const string &ext: supported_extensions){
+        std::size_t startpos = filename.find(ext);
+        if(startpos != string::npos){
+            // Extension found, so remove
+            filename = filename.erase(filename.find(ext), ext.size());
+        }
     }
     for(unsigned int i=0;i<filename.size();i++){
         if(filename.at(i) == '/'){

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -79,6 +79,12 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
     }
     fin.close();
 
+    // Check that this file is the same length as the reference
+    int ref_size = reference.size(); // Cast to int to avoid warnings
+    if(i != ref_size){
+        throw invalid_argument("File " + filename + " is not the same length as the reference genome");
+    }
+
     //For a basic QC check we want to ensure that <20% of the sample is N
     //This should infer that the sample is >=80% ACGT
     //Inherently ref has no Ns, so total Ns == this->N.size()

--- a/test/test_comparisons.cpp
+++ b/test/test_comparisons.cpp
@@ -95,7 +95,7 @@ TEST(comparisons, load_save_thread){
 
 
     vector<Sample*> acc;
-    vector<string> filenames = {"cases/dummy/saves/uuid1", "cases/dummy/saves/uuid2", "cases/dummy/saves/uuid3", "cases/dummy/saves/uuid4", "cases/dummy/saves/uuid5"};
+    vector<string> filenames = {"cases/dummy/saves/uuid1.fn5", "cases/dummy/saves/uuid2.fn5", "cases/dummy/saves/uuid3.fn5", "cases/dummy/saves/uuid4.fn5", "cases/dummy/saves/uuid5.fn5"};
     load_save_thread(filenames, &acc);
 
     ASSERT_TRUE(vectors_equal(expected, acc));
@@ -239,8 +239,8 @@ TEST(comparisons, print_comparisons){
 TEST(comparisons, do_comparisons_from_disk){
     output_file = "test_do_comparisons_from_disk.txt";
     
-    vector<string> paths = {"cases/dummy/saves/uuid1", "cases/dummy/saves/uuid2", "cases/dummy/saves/uuid3", "cases/dummy/saves/uuid4"};
-    Sample *s = readSample("cases/dummy/saves/uuid5");
+    vector<string> paths = {"cases/dummy/saves/uuid1.fn5", "cases/dummy/saves/uuid2.fn5", "cases/dummy/saves/uuid3.fn5", "cases/dummy/saves/uuid4.fn5"};
+    Sample *s = readSample("cases/dummy/saves/uuid5.fn5");
 
     //Ensure output file is empty first
     fstream out(output_file, fstream::out);

--- a/test/test_py_bindings.py
+++ b/test/test_py_bindings.py
@@ -31,3 +31,29 @@ def test_1():
         expected_map[(b, a)] = dist
     
     assert actual_map == expected_map
+
+def test_1_saves():
+    '''This should be all comparisons, using saves rather than fastas
+    '''
+    samples = [fn5.load("test/saves/sample1.fn5"), fn5.load("test/saves/sample2.fn5"), fn5.load("test/saves/sample3.fn5"), fn5.load("test/saves/sample4.fn5"),]
+
+    actual = set(fn5.compute(samples))
+    actual_map = {}
+    for a, b, dist in actual:
+        actual_map[(a, b)] = dist
+        actual_map[(b, a)] = dist
+    expected = [
+        "sample4 sample1 12",
+        "sample4 sample3 11",
+        "sample4 sample2 11",
+        "sample1 sample3 1",
+        "sample1 sample2 1",
+        "sample3 sample2 0",
+        ]
+    expected = set([(x.split(" ")[0], x.split(" ")[1], int(x.split(" ")[2])) for x in expected])
+    expected_map = {}
+    for a, b, dist in expected:
+        expected_map[(a, b)] = dist
+        expected_map[(b, a)] = dist
+    
+    assert actual_map == expected_map

--- a/test/test_sample.cpp
+++ b/test/test_sample.cpp
@@ -515,11 +515,11 @@ TEST(sample, save_load){
     save("cases/dummy/saves", s4);
     save("cases/dummy/saves", s5);
 
-    Sample* s1_save = readSample("cases/dummy/saves/uuid1");
-    Sample* s2_save = readSample("cases/dummy/saves/uuid2");
-    Sample* s3_save = readSample("cases/dummy/saves/uuid3");
-    Sample* s4_save = readSample("cases/dummy/saves/uuid4");
-    Sample* s5_save = readSample("cases/dummy/saves/uuid5");
+    Sample* s1_save = readSample("cases/dummy/saves/uuid1.fn5");
+    Sample* s2_save = readSample("cases/dummy/saves/uuid2.fn5");
+    Sample* s3_save = readSample("cases/dummy/saves/uuid3.fn5");
+    Sample* s4_save = readSample("cases/dummy/saves/uuid4.fn5");
+    Sample* s5_save = readSample("cases/dummy/saves/uuid5.fn5");
 
     ASSERT_EQ(*s1, *s1_save);
     ASSERT_EQ(*s2, *s2_save);


### PR DESCRIPTION
Should auto-migrate existing saves upon loading. Moves from saving each nucleotide as a separate file to saving as a single `.fn5` file.

Tested locally reading from old saves. Performs as expected, converting the old saves into new saves and giving expected results.

Python bindings still work, and can perform the same auto-migration. Should attempt reading the old-style saves before falling back to new-style saves upon failure. This should mean the GPAS API's use case for this shouldn't need immediate updating

fn5_pipeline will need an additional step to ensure that only new-style saves are synced between PVC and bucket, but this should be trivial
