### PR TITLE
fix: use ubuntu 22.04 to avoid python issues

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 #Setup
 RUN apt update --fix-missing
@@ -20,4 +20,4 @@ RUN git clone https://github.com/oxfordmmm/FN5.git && \
     cd FN5 && \
     bash build.sh && \
     cp fn5 /usr/bin/fn5 && \
-    pip install -r requirements.txt --break-system-packages
+    pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from pathlib import Path
 import os
 
-__version__ = "v2.0.1"
+__version__ = "v2.0.2"
 
 try:
     this_directory = Path(__file__).parent

--- a/src/fn5.cpp
+++ b/src/fn5.cpp
@@ -9,7 +9,7 @@ int main(int nargs, const char* args_[]){
     if(nargs == 2){
         string val = args_[1];
         if(val == "--version" || val == "-v"){
-            cout << "v2.0.1" << endl;
+            cout << "v2.0.2" << endl;
             return 0;
         }
     }


### PR DESCRIPTION
For some reason python3.12 doesn't seem to work with this, so pin to ubuntu 22.04 to keep at 3.10