### PR TITLE
fix(uuid): fix bug with uuid parsing

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -24,7 +24,7 @@ Sample::Sample(string filename, string reference, unordered_set<int> mask, strin
             //Line has ended
             break;
         }
-        if(ch == '|'){
+        if(ch == '|' || ch == '>'){
             //New pipe, so reset
             uuid_ = "";
         }


### PR DESCRIPTION
Not an issue with our usual use case as we pass uuid as a parameter, but when attempting to parse covid samples with non-cryptic fasta headers, the leading `>` character is included. Very simple fix for that