### PR TITLE
fix: update dockerfile to remove python reqs

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:latest
 
 #Setup
 RUN apt update --fix-missing
@@ -9,9 +9,6 @@ RUN apt install -y git bash g++
 RUN apt install -y make
 RUN apt install -y cmake
 
-#Install python for DB things
-RUN apt install -y python3 python3-pip mysql-client libmysqlclient-dev
-
 #Script requirements
 RUN apt install -y curl jq pigz
 
@@ -20,4 +17,3 @@ RUN git clone https://github.com/oxfordmmm/FN5.git && \
     cd FN5 && \
     bash build.sh && \
     cp fn5 /usr/bin/fn5 && \
-    pip install -r requirements.txt


### PR DESCRIPTION
I imagine this is 90+% of what vulnerability scanners were picking up on